### PR TITLE
Txn: expose underlying *C.MDB_txn

### DIFF
--- a/lmdb/txn.go
+++ b/lmdb/txn.go
@@ -577,3 +577,8 @@ func (txn *Txn) DCmp(dbi DBI, a []byte, b []byte) int {
 	}
 	return 0
 }
+
+// Underlying *C.MDB_txn
+func (txn *Txn) CHandle() unsafe.Pointer {
+	return unsafe.Pointer(txn._txn)
+}


### PR DESCRIPTION
This is useful for Silkworm integration