### PR TITLE
Fix for reading zero-length values using RawRead

### DIFF
--- a/lmdb/val.go
+++ b/lmdb/val.go
@@ -113,6 +113,9 @@ func wrapVal(b []byte) *C.MDB_val {
 }
 
 func getBytes(val *C.MDB_val) []byte {
+	if val.mv_size == 0 {
+		return []byte{}
+	}
 	return (*[valMaxSize]byte)(val.mv_data)[:val.mv_size:val.mv_size]
 }
 


### PR DESCRIPTION
When reading zero-length values using `RawRead` (ie. `nil`, `empty`) the `getBytes()` function triggers a fatal `SIGBUS` error.
We can avoid this by detecting the case where `val.mv_size == 0` and avoiding attempts to access that memory.

resolves https://github.com/ledgerwatch/lmdb-go/issues/25
ref: https://github.com/ledgerwatch/lmdb-go/blob/master/lmdb/lmdb.h#L255